### PR TITLE
Support for HTTP 307 redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ With only one single dependency, Needle supports:
  - HTTP Proxy forwarding, optionally with authentication
  - Streaming gzip or deflate decompression
  - Automatic XML & JSON parsing
- - 301/302/303 redirect following, with fine-grained tuning, and
+ - 301/302/303/307 redirect following, with fine-grained tuning, and
  - Streaming non-UTF-8 charset decoding, via `iconv-lite`
 
 And yes, Mr. Wayne, it does come with the latest streams2 support.

--- a/lib/needle.js
+++ b/lib/needle.js
@@ -420,13 +420,13 @@ Needle.prototype.send_request = function(count, method, uri, config, post_data, 
     }
 
     // if redirect code is found, send a GET request to that location if enabled via 'follow' option
-    if ([301, 302, 303].indexOf(resp.statusCode) !== -1 && self.should_follow(headers.location, config, uri)) {
+    if ([301, 302, 303, 307].indexOf(resp.statusCode) !== -1 && self.should_follow(headers.location, config, uri)) {
 
       if (count <= config.follow_max) {
         out.emit('redirect', headers.location);
 
         // unless follow_keep_method was set to true, rewrite the request to GET before continuing
-        if (!config.follow_keep_method) {
+        if (!config.follow_keep_method && resp.statusCode != 307) {
           method    = 'GET';
           post_data = null;
           delete config.headers['content-length']; // in case the original was a multipart POST request.


### PR DESCRIPTION
Currently 307 redirect is not supported.

With this small change needle supports 307 redirect and comforts the http protocol not rewriting the method. 
